### PR TITLE
Location provider permissions

### DIFF
--- a/Flaneurs/app/src/main/java/app/flaneurs/com/flaneurs/fragments/MapFragment.java
+++ b/Flaneurs/app/src/main/java/app/flaneurs/com/flaneurs/fragments/MapFragment.java
@@ -26,7 +26,7 @@ import permissions.dispatcher.NeedsPermission;
 import permissions.dispatcher.RuntimePermissions;
 
 @RuntimePermissions
-public class MapFragment extends SupportMapFragment implements LocationProvider.ILocationListener{
+public class MapFragment extends SupportMapFragment implements LocationProvider.ILocationListener {
 
     public static final String TAG = MapFragment.class.getSimpleName();
     public static final String ARG_SHOULD_TRACK_LOCATION = "ARG_SHOULD_TRACK_LOCATION";
@@ -128,7 +128,6 @@ public class MapFragment extends SupportMapFragment implements LocationProvider.
             map.setMyLocationEnabled(true);
             mLocationProvider = FlaneurApplication.getInstance().locationProvider;
             mLocationProvider.addListener(this);
-            mLocationProvider.connect();
         }
     }
 
@@ -139,9 +138,5 @@ public class MapFragment extends SupportMapFragment implements LocationProvider.
             map.animateCamera(cameraUpdate);
         }
         mLocation = location;
-    }
-
-    public Location getCurrentLocation() {
-        return (shouldTrackLocation) ? mLocation : null;
     }
 }

--- a/Flaneurs/app/src/main/java/app/flaneurs/com/flaneurs/utils/LocationProvider.java
+++ b/Flaneurs/app/src/main/java/app/flaneurs/com/flaneurs/utils/LocationProvider.java
@@ -50,6 +50,10 @@ public class LocationProvider implements
         mLocationListeners.add(locationListener);
     }
 
+    public void removeListener(ILocationListener locationListener) {
+        mLocationListeners.remove(locationListener);
+    }
+
     public LocationProvider(Context context) {
         mLocationListeners = new ArrayList<>();
 
@@ -67,6 +71,7 @@ public class LocationProvider implements
                 .setFastestInterval(FASTEST_INTERVAL);
 
         mContext = context;
+        connect();
     }
 
     public void connect() {


### PR DESCRIPTION
Previously the Location Provider would only start providing location updates AFTER we requested location permissions in the MapFragment. This meant that if we were trying to access location before this point (say in DiscoverActivity initialization) there would be no valid location yet. 

To verify this try putting a breakpoint in the LocationProvider `onLocationChanged` method, and note that it never gets fired if you comment out the `MapFragmentPermissionsDispatcher.getMyLocationWithCheck(this)` call in MapFragment.

To address this issue I made the following changes:
- DiscoverActivity now makes the permissions request instead of MapFragment
- DiscoverActivity now also tracks current location, passes this into Compose instead of requesting from MapFragment
- On initialization DiscoverActivity grabs the 5 closest points to the user's location and passes those into the MapFragment to display

Not pushing this directly but putting up a PR so you guys can get a chance to sanity check these changes. It bothers me somewhat that both DiscoverActivity and MapFragment are listening for location updates (I wonder if there's some way to do it all in the activity), if you guys can think of a better solution I'm open to suggestions. 
